### PR TITLE
bin/profile handles commands with quoted parameters

### DIFF
--- a/bin/profile
+++ b/bin/profile
@@ -4,4 +4,4 @@ for FILE in $(find /app/.profile.d/ -name '*.sh'); do
   source $FILE
 done
 
-exec $*
+exec "$@"


### PR DESCRIPTION
from http://tldp.org/LDP/abs/html/internalvariables.html

> `$*` -- All of the positional parameters, seen as a single word.
> `$@` -- Same as $*, but each parameter is a quoted string.
> Of course, "$@" and "$*" should be quoted.

with this change, you can `docker run sh -c 'ls -al'`.  without, it would work but ignore the `-al`.
