### PR TITLE
bail on errors in bin/build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 buildpack="/buildkit"
 


### PR DESCRIPTION
previously errors at buildpack-time would not fail the docker build.  this sets the `-e` flag within `bin/build` so they do.
